### PR TITLE
Fix lint issues by typing collections

### DIFF
--- a/app/epi/api/upload/route.ts
+++ b/app/epi/api/upload/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import * as XLSX from 'xlsx'
 
+interface RawRow {
+  [key: string]: string | undefined
+}
+
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY! // chave de serviço para backend
@@ -19,7 +23,7 @@ export async function POST(req: NextRequest) {
 
   if (!sheet) return NextResponse.json({ error: 'Aba "organizar" não encontrada' }, { status: 400 })
 
-  const json = XLSX.utils.sheet_to_json(sheet) as any[]
+  const json = XLSX.utils.sheet_to_json<RawRow>(sheet)
 
   const registros = json.map(row => ({
     nome: row['nome']?.trim() || '',

--- a/app/epi/page.tsx
+++ b/app/epi/page.tsx
@@ -7,8 +7,15 @@ import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useRouter } from 'next/navigation'
 
+interface Registro {
+  nome: string
+  status: string
+  loja: string
+  consultor: string
+}
+
 export default function Dashboard() {
-  const [dados, setDados] = useState<any[]>([])
+  const [dados, setDados] = useState<Registro[]>([])
   const [filtros, setFiltros] = useState({ status: '', loja: '', consultor: '' })
   const router = useRouter()
 

--- a/app/epi/upload/page.tsx
+++ b/app/epi/upload/page.tsx
@@ -8,7 +8,7 @@ export default function UploadPage() {
   const [msg, setMsg] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [progress, setProgress] = useState(0)
-  const [preview, setPreview] = useState<any[]>([])
+  const [preview, setPreview] = useState<Record<string, string | number>[]>([])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -23,8 +23,8 @@ export default function UploadPage() {
     const data = await file.arrayBuffer()
     const workbook = XLSX.read(data)
     const sheet = workbook.Sheets['organizar'] || workbook.Sheets['ORGANIZAR']
-    const json = XLSX.utils.sheet_to_json(sheet)
-    setPreview(json as any[])
+    const json = XLSX.utils.sheet_to_json<Record<string, string | number>>(sheet)
+    setPreview(json)
 
     const formData = new FormData()
     formData.append('file', file)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -116,7 +116,7 @@ export default function HomeDashboard() {
   )
 }
 
-function CardGrafico({ titulo, dados }: { titulo: string; dados: any[] }) {
+function CardGrafico({ titulo, dados }: { titulo: string; dados: { name: string; value: number }[] }) {
   return (
     <div className="bg-white rounded shadow p-4">
       <h2 className="text-lg font-semibold mb-2">{titulo}</h2>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -5,3 +5,4 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+


### PR DESCRIPTION
## Summary
- fix lint by defining row interface in upload API
- type state and helper generics in EPI pages
- remove last use of `any`

## Testing
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688903cb82f883338e32b8de745a6315