### PR TITLE
Fix Vercel build by deferring Supabase client creation

### DIFF
--- a/app/epi/api/upload/route.ts
+++ b/app/epi/api/upload/route.ts
@@ -5,11 +5,6 @@ import { SSF } from 'xlsx'
 import path from 'path'
 import { mkdir, writeFile, access, readFile } from 'fs/promises'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
-
 function parseDate(v: string | number | Date | null | undefined): string | null {
   if (!v) return null
   if (v instanceof Date) {
@@ -41,6 +36,10 @@ function sanitizeFilename(name: string) {
 }
 
 export async function POST(req: NextRequest) {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  )
   // 1️⃣ obter o arquivo
   const form = await req.formData()
   const file = form.get('file') as File

--- a/app/epi/api/upload/route_.ts
+++ b/app/epi/api/upload/route_.ts
@@ -8,12 +8,11 @@ interface RawRow {
   [key: string]: string | undefined
 }
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY! // chave de serviço para backend
-)
-
 export async function POST(req: NextRequest) {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  )
   const formData = await req.formData()
   const file = formData.get('file') as File
 

--- a/app/epi/page copy.tsx
+++ b/app/epi/page copy.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase'
+import { createSupabase } from '@/lib/supabase'
 import { format, addMonths } from 'date-fns'
 import {
   PieChart, Pie, Cell, ResponsiveContainer,
@@ -40,6 +40,7 @@ export default function EpiDashboard() {
   }, [filtros])
 
   async function fetchData() {
+    const supabase = createSupabase()
     let q = supabase.from('assinaturas_epi').select('*')
     if (filtros.loja)        q = q.eq('loja', filtros.loja)
     if (filtros.consultor)   q = q.eq('consultor', filtros.consultor)

--- a/app/epi/page.tsx
+++ b/app/epi/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase'
+import { createSupabase } from '@/lib/supabase'
 import { format, addMonths } from 'date-fns'
 import Link from 'next/link'
 import {
@@ -43,6 +43,7 @@ export default function EpiDashboard() {
   }, [filtros])
 
   async function fetchData() {
+    const supabase = createSupabase()
     let q = supabase.from('assinaturas_epi').select('*')
     if (filtros.loja)        q = q.eq('loja', filtros.loja)
     if (filtros.consultor)   q = q.eq('consultor', filtros.consultor)

--- a/components/ChartPie.tsx
+++ b/components/ChartPie.tsx
@@ -1,5 +1,12 @@
 // components/ChartPie.tsx
-import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  PieLabelRenderProps,
+} from 'recharts'
 const COLORS = ['#22c55e', '#facc15', '#ef4444']
 
 interface ChartPieProps {
@@ -8,7 +15,7 @@ interface ChartPieProps {
 }
 
 export function ChartPie({ data, title }: ChartPieProps) {
-  const label = (e: any) => `${e.name}\n${e.value}`
+  const label = (e: PieLabelRenderProps) => `${e.name}\n${e.value}`
   return (
     <div className="bg-white rounded shadow p-4">
       <h2 className="text-lg font-semibold mb-2">{title}</h2>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,10 @@
 // lib/supabase.ts
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export function createSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+}
 

--- a/services/assinaturaService copy.ts
+++ b/services/assinaturaService copy.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabase'
+import { createSupabase } from '@/lib/supabase'
 
 /**
  * Tipo para dados do gráfico de status geral de EPIs
@@ -42,6 +42,7 @@ export async function getResumoEpis(loja?: string|null, consultor?: string|null)
   ranking: RankingLoja[]
   resumo: RankingConsultor[]
 }> {
+  const supabase = createSupabase()
   let query = supabase.from('assinaturas_epi').select('*')
   if (loja)      query = query.eq('loja', loja)
   if (consultor) query = query.eq('consultor', consultor)
@@ -90,6 +91,7 @@ export async function getResumoEpis(loja?: string|null, consultor?: string|null)
 export async function getDetalhePorConsultor(
   consultor: string
 ): Promise<DetalheLoja[]> {
+  const supabase = createSupabase()
   const { data, error } = await supabase
     .from('assinaturas_epi')
     .select('loja, epis')

--- a/services/assinaturaService.ts
+++ b/services/assinaturaService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabase';
+import { createSupabase } from '@/lib/supabase';
 
 export type GraficoData = { name: string; value: number };
 export type RankingLoja = { loja: string; problemas: number };
@@ -27,6 +27,7 @@ function applyFilters<Q>(query: Q, filters: Filters): Q {
 export async function getDetalhePorConsultorColaboradores(
   consultor: string
 ): Promise<DetalheLoja[]> {
+  const supabase = createSupabase();
   const { data, error } = await supabase
     .from('assinaturas_epi')
     .select('nome, status, loja')
@@ -60,6 +61,7 @@ export async function getDetalhePorConsultorColaboradores(
 export async function getResumoColaboradores(
   filters: Filters = {}
 ): Promise<GraficoData[]> {
+  const supabase = createSupabase();
   let q = supabase
     .from('assinaturas_epi')
     .select('nome, status, loja, consultor');
@@ -93,6 +95,7 @@ export async function getResumoColaboradores(
 export async function getRankingLojaColaboradores(
   filters: Filters = {}
 ): Promise<RankingLoja[]> {
+  const supabase = createSupabase();
   let q = supabase
     .from('assinaturas_epi')
     .select('nome, status, loja');
@@ -124,6 +127,7 @@ export async function getRankingLojaColaboradores(
 export async function getResumoPorConsultorColaboradores(
   filters: Filters = {}
 ): Promise<RankingConsultor[]> {
+  const supabase = createSupabase();
   let q = supabase
     .from('assinaturas_epi')
     .select('nome, consultor, status, loja');


### PR DESCRIPTION
## Summary
- avoid top-level Supabase client creation so env vars are read at runtime
- type Pie chart label correctly
- update pages and services to lazily create the Supabase client
- fix duplicate copies of service and page

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688be9cbc1408333b736d51bce7369d4