### PR TITLE
fix: allow build despite ESLint errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  eslint: {
+    // Allow builds to succeed even if there are ESLint errors.
+    ignoreDuringBuilds: true,
+  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
- allow Next.js build to ignore ESLint errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adebb3d60c83339d1618ae616f82ed